### PR TITLE
fix PaperLoreHandler not showing custom enchants

### DIFF
--- a/src/main/java/io/zivoric/enchantmentcore/EnchantmentCore.java
+++ b/src/main/java/io/zivoric/enchantmentcore/EnchantmentCore.java
@@ -151,7 +151,7 @@ public class EnchantmentCore extends JavaPlugin {
                                     } else {
                                         levelRange = DefaultLoreHandler.getRomanNumeral(1) + "-" + DefaultLoreHandler.getRomanNumeral(ce.getMaxLevel());
                                     }
-                                    sender.sendMessage(ChatColor.GRAY + " - " + chatColor + ce.getName().toLowerCase() + ", " + ce.getDisplayName() + " " + levelRange);
+                                    sender.sendMessage(ChatColor.GRAY + " - " + chatColor + ce.getKey() + ", " + ce.getDisplayName() + " " + levelRange);
                                 }
                                 break;
                             } else {

--- a/src/main/java/io/zivoric/enchantmentcore/paper/PaperCustomEnch.java
+++ b/src/main/java/io/zivoric/enchantmentcore/paper/PaperCustomEnch.java
@@ -6,7 +6,6 @@ import io.zivoric.enchantmentcore.EnchantmentHolder;
 import io.zivoric.enchantmentcore.utils.EnchEnums.Rarity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityCategory;
 import org.bukkit.inventory.EquipmentSlot;
@@ -44,7 +43,7 @@ public abstract class PaperCustomEnch extends CustomEnch {
         if (level != 1 || this.getMaxLevel() != 1) {
             component = component.append(Component.space()).append(Component.translatable("enchantment.level." + level));
         }
-        component = component.color(this.isCursed() ? NamedTextColor.RED : NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false);
+        component = component.color(this.isCursed() ? NamedTextColor.RED : NamedTextColor.GRAY);
         return component;
     }
 

--- a/src/main/java/io/zivoric/enchantmentcore/utils/EnchantmentUtils.java
+++ b/src/main/java/io/zivoric/enchantmentcore/utils/EnchantmentUtils.java
@@ -51,7 +51,7 @@ public class EnchantmentUtils {
         }
 
         LORE_HANDLER_LIST.addFirst(new DefaultLoreHandler());
-        if (VersionUtils.BUKKIT_TYPE == BukkitType.PAPER) {
+        if (mcVersion >= 16 && VersionUtils.BUKKIT_TYPE == BukkitType.PAPER) {
             LORE_HANDLER_LIST.addFirst(new PaperLoreHandler());
         }
     }

--- a/src/main/java/io/zivoric/enchantmentcore/utils/lore/PaperLoreHandler.java
+++ b/src/main/java/io/zivoric/enchantmentcore/utils/lore/PaperLoreHandler.java
@@ -3,8 +3,7 @@ package io.zivoric.enchantmentcore.utils.lore;
 import io.zivoric.enchantmentcore.CustomEnch;
 import io.zivoric.enchantmentcore.paper.PaperCustomEnch;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -15,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PaperLoreHandler implements LoreHandler {
-    private static final Component ENCH_CODE = Component.text("", Style.style(TextDecoration.OBFUSCATED)).append(Component.text(" ", Style.style(NamedTextColor.GRAY, TextDecoration.OBFUSCATED)));
+    private static final Component ENCH_CODE = Component.empty().color(TextColor.color(0xfa02ff)).append(Component.empty().color(TextColor.color(0x26b8ff)));
 
     @Override
     public Map<CustomEnch, Integer> updateItemLore(ItemMeta meta, Map<CustomEnch, Integer> currentEnchantMap) {
@@ -26,7 +25,7 @@ public class PaperLoreHandler implements LoreHandler {
         currentEnchantMap.forEach((ench, level) -> {
             if (ench instanceof PaperCustomEnch) {
                 if (showEnchants) {
-                    createdLore.add(ench.displayName(level).append(ENCH_CODE));
+                    createdLore.add(ench.displayName(level).decoration(TextDecoration.ITALIC, false).append(ENCH_CODE));
                 }
             } else {
                 remaining.put(ench, level);


### PR DESCRIPTION
Somehow the item doesn't show the PaperCustomEnch lore.